### PR TITLE
implement shell featue

### DIFF
--- a/packages/sui-cli/src/commands/build.ts
+++ b/packages/sui-cli/src/commands/build.ts
@@ -3,6 +3,7 @@ import { execSync, exec } from 'child_process';
 import chalk from 'chalk';
 import { DubheConfig, loadConfig } from '@0xobelisk/sui-common';
 import { switchEnv, updateDubheDependency } from '../utils';
+import { handler_exit } from './shell';
 
 type Options = {
   'config-path': string;
@@ -52,11 +53,11 @@ const commandModule: CommandModule<Options, Options> = {
       }`;
       const output = execSync(command, { encoding: 'utf-8' });
       console.log(output);
-      exec(`pnpm dubhe convert-json --config-path ${configPath}`)
+      exec(`pnpm dubhe convert-json --config-path ${configPath}`);
     } catch (error: any) {
       console.error(chalk.red('Error executing sui move build:'));
       console.log(error.stdout);
-      process.exit(0);
+      handler_exit(0);
     }
   }
 };

--- a/packages/sui-cli/src/commands/checkBalance.ts
+++ b/packages/sui-cli/src/commands/checkBalance.ts
@@ -1,5 +1,6 @@
 import type { CommandModule } from 'yargs';
 import { checkBalanceHandler } from '../utils/checkBalance';
+import { handler_exit } from './shell';
 
 type Options = {
   network: 'mainnet' | 'testnet' | 'devnet' | 'localnet';
@@ -21,9 +22,9 @@ const commandModule: CommandModule<Options, Options> = {
       await checkBalanceHandler(network);
     } catch (error) {
       console.error('Error checking balance:', error);
-      process.exit(1);
+      handler_exit(1);
     }
-    process.exit(0);
+    handler_exit(0);
   }
 };
 

--- a/packages/sui-cli/src/commands/configStore.ts
+++ b/packages/sui-cli/src/commands/configStore.ts
@@ -1,6 +1,7 @@
 import type { CommandModule } from 'yargs';
 import { storeConfigHandler } from '../utils/storeConfig';
 import { loadConfig, DubheConfig } from '@0xobelisk/sui-common';
+import { handler_exit } from './shell';
 
 type Options = {
   'config-path': string;
@@ -35,9 +36,9 @@ const commandModule: CommandModule<Options, Options> = {
       await storeConfigHandler(dubheConfig, network, outputTsPath);
     } catch (error) {
       console.error('Error storing config:', error);
-      process.exit(1);
+      handler_exit(1);
     }
-    process.exit(0);
+    handler_exit(0);
   }
 };
 

--- a/packages/sui-cli/src/commands/convertJson.ts
+++ b/packages/sui-cli/src/commands/convertJson.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { DubheConfig, loadConfig } from '@0xobelisk/sui-common';
 import { generateConfigJson } from '../utils';
 import fs from 'fs';
+import { handler_exit } from './shell';
 
 type Options = {
   'config-path': string;
@@ -27,10 +28,7 @@ const commandModule: CommandModule<Options, Options> = {
     });
   },
 
-  async handler({
-    'config-path': configPath,
-    'output-path': outputPath
-  }) {
+  async handler({ 'config-path': configPath, 'output-path': outputPath }) {
     // Start an internal anvil process if no world address is provided
     try {
       console.log('🚀 Running convert json');
@@ -41,7 +39,7 @@ const commandModule: CommandModule<Options, Options> = {
     } catch (error: any) {
       console.error(chalk.red('Error executing convert json:'));
       console.log(error.stdout);
-      process.exit(0);
+      handler_exit();
     }
   }
 };

--- a/packages/sui-cli/src/commands/doctor.ts
+++ b/packages/sui-cli/src/commands/doctor.ts
@@ -11,6 +11,7 @@ import * as net from 'net';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import packageJson from '../../package.json';
+import { handler_exit } from './shell';
 
 // Check result type
 interface CheckResult {
@@ -1169,7 +1170,7 @@ async function runDoctorChecks(options: {
     const toolName = options.listVersions;
     if (!TOOL_CONFIGS[toolName]) {
       console.error(chalk.red(`❌ Unsupported tool: ${toolName}`));
-      process.exit(1);
+      handler_exit(1);
     }
 
     console.log(chalk.blue(`📋 Available versions for ${toolName}:`));
@@ -1182,7 +1183,7 @@ async function runDoctorChecks(options: {
 
     if (releases.length === 0) {
       console.log(chalk.red('Unable to get version information'));
-      process.exit(1);
+      handler_exit(1);
     }
 
     // Process version compatibility check
@@ -1232,7 +1233,7 @@ async function runDoctorChecks(options: {
       }
     }
 
-    process.exit(0);
+    handler_exit(0);
   }
 
   console.log(chalk.gray('Checking your development environment...\n'));
@@ -1243,14 +1244,14 @@ async function runDoctorChecks(options: {
     if (!TOOL_CONFIGS[toolName]) {
       console.error(chalk.red(`❌ Unsupported tool: ${toolName}`));
       console.log(chalk.gray(`Supported tools: ${Object.keys(TOOL_CONFIGS).join(', ')}`));
-      process.exit(1);
+      handler_exit(1);
     }
 
     let version: string | null = null;
     if (options.selectVersion) {
       version = await selectVersion(toolName);
       if (!version) {
-        process.exit(1);
+        handler_exit(1);
       }
     } else if (toolName === 'dubhe-indexer') {
       // Default to sui-cli version for dubhe-indexer
@@ -1261,7 +1262,7 @@ async function runDoctorChecks(options: {
     }
 
     const success = await downloadAndInstallTool(toolName, version || undefined);
-    process.exit(success ? 0 : 1);
+    handler_exit(success ? 0 : 1);
   }
 
   const results: CheckResult[] = [];
@@ -1553,7 +1554,7 @@ async function runDoctorChecks(options: {
           '\n❌ Your environment has some issues. Please fix them according to the suggestions above.'
         )
       );
-      process.exit(1);
+      handler_exit(1);
     } else if (summary.warning > 0) {
       console.log(
         chalk.yellow(
@@ -1610,7 +1611,7 @@ const commandModule: CommandModule = {
       });
     } catch (error) {
       console.error(chalk.red('Error occurred during check:'), error);
-      process.exit(1);
+      handler_exit(1);
     }
   }
 };

--- a/packages/sui-cli/src/commands/faucet.ts
+++ b/packages/sui-cli/src/commands/faucet.ts
@@ -2,6 +2,7 @@ import type { CommandModule } from 'yargs';
 import { requestSuiFromFaucetV0, getFaucetHost } from '@mysten/sui/faucet';
 import { SuiClient, getFullnodeUrl, GetBalanceParams } from '@mysten/sui/client';
 import { initializeDubhe } from '../utils';
+import { handler_exit } from './shell';
 
 type Options = {
   network: any;
@@ -63,7 +64,7 @@ const commandModule: CommandModule<Options, Options> = {
       isInterrupted = true;
       process.stdout.write('\r' + ' '.repeat(50) + '\r');
       console.log('\n  └─ Operation cancelled by user');
-      process.exit(0);
+      handler_exit();
     };
     process.on('SIGINT', handleInterrupt);
 
@@ -82,7 +83,7 @@ const commandModule: CommandModule<Options, Options> = {
           if (retryCount === MAX_RETRIES) {
             console.log(`  └─ Failed to request funds after ${MAX_RETRIES} attempts.`);
             console.log('  └─ Please check your network connection and try again later.');
-            process.exit(1);
+            handler_exit(1);
           }
 
           const elapsedTime = Math.floor((Date.now() - startTime) / 1000);
@@ -98,7 +99,7 @@ const commandModule: CommandModule<Options, Options> = {
     }
 
     if (isInterrupted) {
-      process.exit(0);
+      handler_exit();
     }
     process.stdout.write('\r' + ' '.repeat(50) + '\r');
 
@@ -115,7 +116,7 @@ const commandModule: CommandModule<Options, Options> = {
     console.log(`  └─ Balance: ${(Number(balance.totalBalance) / 1_000_000_000).toFixed(4)} SUI`);
 
     console.log('\n✅ Faucet Operation Complete\n');
-    process.exit(0);
+    handler_exit();
   }
 };
 

--- a/packages/sui-cli/src/commands/generateKey.ts
+++ b/packages/sui-cli/src/commands/generateKey.ts
@@ -1,5 +1,6 @@
 import type { CommandModule } from 'yargs';
 import { generateAccountHandler } from '../utils/generateAccount';
+import { handler_exit } from './shell';
 
 type Options = {
   force?: boolean;
@@ -26,9 +27,9 @@ const commandModule: CommandModule<Options, Options> = {
       await generateAccountHandler(force, useNextPublic);
     } catch (error) {
       console.error('Error generating account:', error);
-      process.exit(1);
+      handler_exit(1);
     }
-    process.exit(0);
+    handler_exit();
   }
 };
 

--- a/packages/sui-cli/src/commands/index.ts
+++ b/packages/sui-cli/src/commands/index.ts
@@ -18,6 +18,7 @@ import loadMetadata from './loadMetadata';
 import doctor from './doctor';
 import convertJson from './convertJson';
 import upgrade from './upgrade';
+import shell from './shell';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Each command has different options
 export const commands: CommandModule<any, any>[] = [
@@ -40,5 +41,6 @@ export const commands: CommandModule<any, any>[] = [
   info,
   loadMetadata,
   doctor,
-  convertJson
+  convertJson,
+  shell
 ];

--- a/packages/sui-cli/src/commands/info.ts
+++ b/packages/sui-cli/src/commands/info.ts
@@ -3,6 +3,7 @@ import { logError, initializeDubhe } from '../utils';
 import dotenv from 'dotenv';
 import chalk from 'chalk';
 dotenv.config();
+import { handler_exit } from './shell';
 
 type Options = {
   network: any;
@@ -41,7 +42,7 @@ const InfoCommand: CommandModule<Options, Options> = {
       }
     } catch (error) {
       logError(error);
-      process.exit(1);
+      handler_exit(1);
     }
   }
 };

--- a/packages/sui-cli/src/commands/loadMetadata.ts
+++ b/packages/sui-cli/src/commands/loadMetadata.ts
@@ -2,6 +2,7 @@ import type { CommandModule } from 'yargs';
 import { logError } from '../utils/errors';
 import { loadConfig, DubheConfig } from '@0xobelisk/sui-common';
 import { loadMetadataHandler } from '../utils/metadataHandler';
+import { handler_exit } from './shell';
 
 type Options = {
   network: any;
@@ -41,9 +42,9 @@ const commandModule: CommandModule<Options, Options> = {
       await loadMetadataHandler(dubheConfig, network, packageId);
     } catch (error: any) {
       logError(error);
-      process.exit(1);
+      handler_exit(1);
     }
-    process.exit(0);
+    handler_exit();
   }
 };
 

--- a/packages/sui-cli/src/commands/localnode.ts
+++ b/packages/sui-cli/src/commands/localnode.ts
@@ -1,5 +1,6 @@
 import type { CommandModule } from 'yargs';
 import { startLocalNode } from '../utils/startNode';
+import { handler_exit } from './shell';
 
 type Options = {
   'data-dir': string;
@@ -29,7 +30,7 @@ const commandModule: CommandModule<Options, Options> = {
       await startLocalNode(data_dir, force);
     } catch (error) {
       console.error('Error executing command:', error);
-      process.exit(1);
+      handler_exit(1);
     }
   }
 };

--- a/packages/sui-cli/src/commands/publish.ts
+++ b/packages/sui-cli/src/commands/publish.ts
@@ -3,6 +3,7 @@ import { logError } from '../utils/errors';
 import { publishHandler } from '../utils';
 import { loadConfig, DubheConfig } from '@0xobelisk/sui-common';
 import { execSync } from 'child_process';
+import { handler_exit } from './shell';
 
 type Options = {
   network: any;
@@ -39,13 +40,13 @@ const commandModule: CommandModule<Options, Options> = {
   async handler({ network, 'config-path': configPath, 'gas-budget': gasBudget }) {
     try {
       const dubheConfig = (await loadConfig(configPath)) as DubheConfig;
-      execSync(`pnpm dubhe convert-json --config-path ${configPath}`, { encoding: 'utf-8' })
-      await publishHandler(dubheConfig, network, gasBudget); 
+      execSync(`pnpm dubhe convert-json --config-path ${configPath}`, { encoding: 'utf-8' });
+      await publishHandler(dubheConfig, network, gasBudget);
     } catch (error: any) {
       logError(error);
-      process.exit(1);
+      handler_exit(1);
     }
-    process.exit(0);
+    handler_exit();
   }
 };
 

--- a/packages/sui-cli/src/commands/schemagen.ts
+++ b/packages/sui-cli/src/commands/schemagen.ts
@@ -2,6 +2,7 @@ import type { CommandModule } from 'yargs';
 import { schemaGen, loadConfig, DubheConfig } from '@0xobelisk/sui-common';
 import chalk from 'chalk';
 import path from 'node:path';
+import { handler_exit } from './shell';
 
 type Options = {
   'config-path'?: string;
@@ -32,7 +33,7 @@ const commandModule: CommandModule<Options, Options> = {
       const dubheConfig = (await loadConfig(configPath)) as DubheConfig;
       const rootDir = path.dirname(configPath);
       await schemaGen(rootDir, dubheConfig, network);
-      process.exit(0);
+      handler_exit();
     } catch (error: any) {
       console.log(chalk.red('Schemagen failed!'));
       console.error(error.message);

--- a/packages/sui-cli/src/commands/schemagen.ts
+++ b/packages/sui-cli/src/commands/schemagen.ts
@@ -1,7 +1,7 @@
 import type { CommandModule } from 'yargs';
 import { schemaGen, loadConfig, DubheConfig } from '@0xobelisk/sui-common';
 import chalk from 'chalk';
-import path from "node:path";
+import path from 'node:path';
 
 type Options = {
   'config-path'?: string;

--- a/packages/sui-cli/src/commands/shell.ts
+++ b/packages/sui-cli/src/commands/shell.ts
@@ -48,7 +48,7 @@ const ShellCommand: CommandModule<Options, Options> = {
       historySize: 200
     });
 
-    rl.on('line', (line) => {
+    rl.on('line', async (line) => {
       const fullCommand = line.trim();
       if (!fullCommand) {
         rl.prompt();
@@ -69,7 +69,7 @@ const ShellCommand: CommandModule<Options, Options> = {
           if (builder) {
             const argv = yargsInstance.parseSync([commandName, ...parts.slice(1)]);
             if (handler) {
-              handler(argv);
+              await handler(argv);
             }
           }
         } catch (error) {

--- a/packages/sui-cli/src/commands/shell.ts
+++ b/packages/sui-cli/src/commands/shell.ts
@@ -8,6 +8,12 @@ import chalk from 'chalk';
 dotenv.config();
 import { printDubhe } from '../utils';
 
+let shouldHandlerExit = true;
+
+export const handler_exit = (status: number = 0) => {
+  if (shouldHandlerExit) process.exit(status);
+};
+
 type Options = {
   network: any;
 };
@@ -30,6 +36,7 @@ const ShellCommand: CommandModule<Options, Options> = {
     });
   },
   handler: async ({ network }) => {
+    shouldHandlerExit = false;
     const commandHistory: string[] = [];
 
     function completer(line: string) {

--- a/packages/sui-cli/src/commands/shell.ts
+++ b/packages/sui-cli/src/commands/shell.ts
@@ -1,0 +1,125 @@
+import readline from 'readline';
+
+import yargs, { CommandModule } from 'yargs';
+import dotenv from 'dotenv';
+import { commands } from '.';
+import { hideBin } from 'yargs/helpers';
+import chalk from 'chalk';
+dotenv.config();
+import { printDubhe } from '../utils';
+
+type Options = {
+  network: any;
+};
+
+const parseCommandNames = () => {
+  return commands.map((command) => command.command);
+};
+
+const ShellCommand: CommandModule<Options, Options> = {
+  command: 'shell',
+  describe: 'Open a shell to interact with the Dubhe System',
+  builder(yargs) {
+    return yargs.options({
+      network: {
+        type: 'string',
+        choices: ['mainnet', 'testnet', 'devnet', 'localnet'],
+        default: 'localnet',
+        desc: 'Node network (mainnet/testnet/devnet/localnet)'
+      }
+    });
+  },
+  handler: async ({ network }) => {
+    const commandHistory: string[] = [];
+
+    function completer(line: string) {
+      const hits = parseCommandNames().filter((c) => {
+        if (!c) return false;
+        return (c as string).startsWith(line.toLowerCase());
+      });
+      return [hits.length ? hits : parseCommandNames(), line];
+    }
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      prompt: `dubhe(${chalk.green(network)}) ${chalk.bold('>')} `,
+      completer: completer,
+      historySize: 200
+    });
+
+    rl.on('line', (line) => {
+      const fullCommand = line.trim();
+      if (!fullCommand) {
+        rl.prompt();
+        return;
+      }
+
+      // Add command to history
+      commandHistory.push(fullCommand);
+
+      const parts = fullCommand.split(/\s+/);
+      const commandName = parts[0].toLowerCase();
+
+      const command = commands.find((c) => c.command === commandName);
+      if (command) {
+        try {
+          const { builder, handler } = command;
+          const yargsInstance = yargs(hideBin(process.argv));
+          if (builder) {
+            const argv = yargsInstance.parseSync([commandName, ...parts.slice(1)]);
+            if (handler) {
+              handler(argv);
+            }
+          }
+        } catch (error) {
+          console.log(chalk.red(error));
+        }
+      } else if (commandName == 'help') {
+        console.log('Available dubhe commands:');
+
+        // Find the longest command name for alignment
+        const maxCommandLength = Math.max(
+          ...commands.map((c) => {
+            const command =
+              typeof c.command === 'string'
+                ? c.command
+                : Array.isArray(c.command)
+                  ? c.command[0]
+                  : '';
+            return command.length;
+          })
+        );
+
+        commands.forEach((c) => {
+          const command =
+            typeof c.command === 'string'
+              ? c.command
+              : Array.isArray(c.command)
+                ? c.command[0]
+                : '';
+          const paddedCommand = command.padEnd(maxCommandLength);
+          console.log(`  ${chalk.green(paddedCommand)}  ${c.describe}`);
+        });
+        rl.prompt();
+        return;
+      } else if (['exit', 'quit'].indexOf(commandName) !== -1) {
+        console.log('Goodbye You will have a nice day! 👋');
+        rl.close();
+        return;
+      } else {
+        console.log(`🤷‍♀️ Unknown command: "${fullCommand}". Type 'help' to see available commands.`);
+      }
+      rl.prompt();
+    });
+
+    rl.on('close', () => {
+      process.exit(0);
+    });
+
+    printDubhe();
+    rl.prompt();
+  }
+};
+
+export default ShellCommand;

--- a/packages/sui-cli/src/commands/test.ts
+++ b/packages/sui-cli/src/commands/test.ts
@@ -1,6 +1,7 @@
 import type { CommandModule } from 'yargs';
 import { execSync } from 'child_process';
 import { DubheConfig, loadConfig } from '@0xobelisk/sui-common';
+import { handler_exit } from './shell';
 
 type Options = {
   'config-path': string;
@@ -44,7 +45,7 @@ const commandModule: CommandModule<Options, Options> = {
       } --gas-limit ${gasLimit}`;
       execSync(command, { stdio: 'inherit', encoding: 'utf-8' });
     } catch (error: any) {
-      process.exit(0);
+      handler_exit(1);
     }
   }
 };

--- a/packages/sui-cli/src/commands/upgrade.ts
+++ b/packages/sui-cli/src/commands/upgrade.ts
@@ -2,6 +2,7 @@ import type { CommandModule } from 'yargs';
 import { logError } from '../utils/errors';
 import { upgradeHandler } from '../utils/upgradeHandler';
 import { DubheConfig, loadConfig } from '@0xobelisk/sui-common';
+import { handler_exit } from './shell';
 
 type Options = {
   network: any;
@@ -35,9 +36,9 @@ const commandModule: CommandModule<Options, Options> = {
       await upgradeHandler(dubheConfig, dubheConfig.name, network);
     } catch (error: any) {
       logError(error);
-      process.exit(1);
+      handler_exit(1);
     }
-    process.exit(0);
+    handler_exit();
   }
 };
 

--- a/packages/sui-cli/src/commands/wait.ts
+++ b/packages/sui-cli/src/commands/wait.ts
@@ -3,6 +3,7 @@ import waitOn from 'wait-on';
 import ora from 'ora';
 import chalk from 'chalk';
 import net from 'net';
+import { handler_exit } from './shell';
 
 interface WaitOptions {
   url?: string;
@@ -144,7 +145,7 @@ const commandModule: CommandModule = {
         spinner.succeed(chalk.green('Service is ready!'));
       }
 
-      process.exit(0);
+      handler_exit();
     } catch (error) {
       const spinner = ora();
       spinner.fail(
@@ -165,7 +166,7 @@ const commandModule: CommandModule = {
         console.error(chalk.yellow('Please make sure the service is running...'));
       }
 
-      process.exit(1);
+      handler_exit(1);
     }
   }
 };

--- a/packages/sui-cli/src/commands/watch.ts
+++ b/packages/sui-cli/src/commands/watch.ts
@@ -1,6 +1,7 @@
 import type { CommandModule } from 'yargs';
 import chokidar from 'chokidar';
 import { exec } from 'child_process';
+import { handler_exit } from './shell';
 
 const commandModule: CommandModule = {
   command: 'watch',
@@ -42,7 +43,7 @@ const commandModule: CommandModule = {
     process.on('SIGINT', () => {
       watcher.close();
       console.log('\nWatch stopped.');
-      process.exit();
+      handler_exit();
     });
   }
 };

--- a/templates/101/sui-template/mprocs.yaml
+++ b/templates/101/sui-template/mprocs.yaml
@@ -12,3 +12,6 @@ procs:
   node:
     cwd: packages/contracts
     shell: pnpm dubhe node --force
+  shell:
+    cwd: packages/contracts
+    shell: pnpm dubhe shell


### PR DESCRIPTION
Add a shell process  attached to mprocs, then developers can operate the dubhe dapp.

How to do ?
I add a `src/commands/shell.ts` with readline which helps history 、autocomplete and other shell featues. 
Then parse the input line to args by builder defined in commandModule.
At last execute the hander. 

Most important : we should not exit if we run the handler in shell. 